### PR TITLE
Update to UC20 & latest mir-kiosk-snap-launch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
   This snap provides a hello world qml qt app that runs on
   mir-kiosk using wayland and EGL
 confinement: strict
-base: core18
+base: core20
 grade: stable
 
 plugs:
@@ -35,9 +35,13 @@ plugs:
 
 apps:
   daemon:
-    command: daemon.sh
     daemon: simple
-  echo: 
+    restart-condition: always
+    command-chain:
+      - bin/run-daemon
+      - bin/wayland-launch
+    command: daemon.sh
+  echo:
     command: echo.sh
 
 environment:


### PR DESCRIPTION
This updates the daemon app to match the updates recommendations here: https://github.com/MirServer/mir-kiosk-snap-launch/commit/9b971771be84ff0a57a4db141e80589d2a2b98dd

It also updates the base snap to core20, which is important because the latest Qt needs `GLIBC_2.28`